### PR TITLE
Set CSP-Nonce

### DIFF
--- a/changelog/unreleased/set-csp-nonce.md
+++ b/changelog/unreleased/set-csp-nonce.md
@@ -1,0 +1,4 @@
+Bugfix: Generate a random CSP-Nonce in the webapp
+
+https://github.com/owncloud/ocis-konnectd/issues/17
+https://github.com/owncloud/ocis-konnectd/pull/29

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,8 @@ require (
 	github.com/spf13/viper v1.6.1
 	go.opencensus.io v0.22.2
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa
-	stash.kopano.io/kc/konnect v0.28.0
+	stash.kopano.io/kc/konnect v0.28.1
+	stash.kopano.io/kgol/rndm v1.1.0
 )
 
 replace stash.kopano.io/kc/konnect => github.com/IljaN/konnect v0.29.0-alpha2

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -18,6 +18,7 @@ import (
 	"stash.kopano.io/kc/konnect/bootstrap"
 	kcconfig "stash.kopano.io/kc/konnect/config"
 	"stash.kopano.io/kc/konnect/server"
+	"stash.kopano.io/kgol/rndm"
 )
 
 // Service defines the extension handlers.
@@ -212,8 +213,10 @@ func (k Konnectd) Index() http.HandlerFunc {
 
 	// TODO add environment variable to make the path prefix configurable
 	pp := "/signin/v1"
-
 	indexHTML := bytes.Replace(template, []byte("__PATH_PREFIX__"), []byte(pp), 1)
+
+	nonce := rndm.GenerateRandomString(32)
+	indexHTML = bytes.Replace(indexHTML, []byte("__CSP_NONCE__"), []byte(nonce), 1)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
As we overwrite kopano-index handler to serve index from vfs, we need to do this manually.

Similar to ```__PATH_PREFIX__``` there is also ```__CSP_NONCE__``` in the index.html

Fixes #17 