### PR TITLE
Tracing

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -471,6 +471,7 @@ github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5X
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.2 h1:nY8Hti+WKaP0cRsSeQ026wU03QsM762XBeCXBb9NAWI=

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -35,6 +35,7 @@ func Server(cfg *config.Config) *cli.Command {
 			}
 
 			// StringSliceFlag doesn't support Destination
+			// UPDATE Destination on string flags supported. Wait for https://github.com/urfave/cli/pull/1078 to get to micro/cli
 			if len(c.StringSlice("trusted-proxy")) > 0 {
 				cfg.Konnectd.TrustedProxy = c.StringSlice("trusted-proxy")
 			}
@@ -82,6 +83,10 @@ func Server(cfg *config.Config) *cli.Command {
 							ServiceName:       cfg.Tracing.Service,
 						},
 					)
+
+					logger.Info().
+						Str("collector", cfg.Tracing.Collector).
+						Msg("Trace collector added")
 
 					if err != nil {
 						logger.Error().

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -74,9 +74,11 @@ func Server(opts ...Option) (http.Service, error) {
 	)
 
 	{
+		if options.Config.Tracing.Enabled {
+			handle = svc.NewTracing(handle)
+		}
 		handle = svc.NewInstrument(handle, options.Metrics)
 		handle = svc.NewLogging(handle, options.Logger)
-		handle = svc.NewTracing(handle)
 	}
 
 	service.Handle(

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -15,6 +15,7 @@ import (
 	logw "github.com/owncloud/ocis-konnectd/pkg/log"
 	"github.com/owncloud/ocis-konnectd/pkg/middleware"
 	"github.com/owncloud/ocis-pkg/v2/log"
+	"go.opencensus.io/trace"
 	"stash.kopano.io/kc/konnect/bootstrap"
 	kcconfig "stash.kopano.io/kc/konnect/config"
 	"stash.kopano.io/kc/konnect/server"
@@ -219,8 +220,12 @@ func (k Konnectd) Index() http.HandlerFunc {
 	indexHTML = bytes.Replace(indexHTML, []byte("__CSP_NONCE__"), []byte(nonce), 1)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if k.config.Tracing.Enabled {
+			_, span := trace.StartSpan(r.Context(), "/identifier/index.html")
+			defer span.End()
+		}
+
 		w.WriteHeader(http.StatusOK)
 		w.Write(indexHTML)
 	})
-
 }


### PR DESCRIPTION
To enable tracing:

```
KONNECTD_TLS=false \
go run cmd/ocis-konnectd/main.go server \
--tracing-enabled \
--tracing-type jaeger \
--tracing-collector http://localhost:14268/api/traces
```

in order to start the collector:

```
docker run -d --name jaeger \
  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
  -p 5775:5775/udp \
  -p 6831:6831/udp \
  -p 6832:6832/udp \
  -p 5778:5778 \
  -p 16686:16686 \
  -p 14268:14268 \
  -p 9411:9411 \
  jaegertracing/all-in-one:1.6
```

Jaeger UI:: `http://localhost:16686`