### PR TITLE
integrate with current ocis config

### DIFF
--- a/changelog/unreleased/new-ocis-config.md
+++ b/changelog/unreleased/new-ocis-config.md
@@ -1,0 +1,8 @@
+Change: use glauth as ldap backend, default to running behind ocis-proxy
+
+We changed the default configuration to integrate better with ocis.
+
+The default ldap port changes to 9125, which is used by ocis-glauth and we use ocis-proxy to do the tls offloading.
+Clients are supposed to use the ocis-proxy endpoint `https://localhost:9200`
+
+https://github.com/owncloud/ocis-konnectd/pull/52

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -161,7 +161,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Name:        "iss",
 			Usage:       "OIDC issuer URL",
 			EnvVars:     []string{"KONNECTD_ISS"},
-			Value:       "https://localhost:9130",
+			Value:       "https://localhost:9200",
 			Destination: &cfg.Konnectd.Iss,
 		},
 		&cli.StringSliceFlag{
@@ -271,7 +271,7 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			Name:        "tls",
 			Usage:       "Use TLS (disable only if konnectd is behind a TLS-terminating reverse-proxy).",
 			EnvVars:     []string{"KONNECTD_TLS"},
-			Value:       true,
+			Value:       false,
 			Destination: &cfg.HTTP.TLS,
 		},
 		&cli.StringSliceFlag{

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -109,8 +109,8 @@ func createConfigsIfNotExist(assets http.FileSystem) error {
 func initKonnectInternalEnvVars() error {
 	var defaults = map[string]string{
 		"LDAP_URI":                 "ldap://localhost:9125",
-		"LDAP_BINDDN":              "cn=admin,dc=example,dc=org",
-		"LDAP_BINDPW":              "admin",
+		"LDAP_BINDDN":              "cn=konnectd,ou=sysusers,dc=example,dc=org",
+		"LDAP_BINDPW":              "konnectd",
 		"LDAP_BASEDN":              "ou=users,dc=example,dc=org",
 		"LDAP_SCOPE":               "sub",
 		"LDAP_LOGIN_ATTRIBUTE":     "uid",
@@ -118,7 +118,7 @@ func initKonnectInternalEnvVars() error {
 		"LDAP_NAME_ATTRIBUTE":      "cn",
 		"LDAP_UUID_ATTRIBUTE":      "customuid",
 		"LDAP_UUID_ATTRIBUTE_TYPE": "text",
-		"LDAP_FILTER":              "(objectClass=person)",
+		"LDAP_FILTER":              "(objectClass=posixaccount)",
 	}
 
 	for k, v := range defaults {


### PR DESCRIPTION
We changed the default configuration to integrate better with ocis.

The default ldap port changes to 9125, which is used by ocis-glauth and we use ocis-proxy to do the tls offloading.
Clients are supposed to use the ocis-proxy endpoint `https://localhost:9200`

Requires https://github.com/owncloud/ocis-glauth/pull/9