### PR TITLE
Change default settings to be able to run ocis server without any con…

### DIFF
--- a/changelog/unreleased/change-internal-defaults.md
+++ b/changelog/unreleased/change-internal-defaults.md
@@ -1,3 +1,3 @@
-Enhancement: Change internal-default config to have zero-configuration in single-binary mode
+Enhancement: Change default config for single-binary 
 
 https://github.com/owncloud/ocis-konnectd/pull/55

--- a/changelog/unreleased/change-internal-defaults.md
+++ b/changelog/unreleased/change-internal-defaults.md
@@ -1,0 +1,3 @@
+Enhancement: Change internal-default config to have zero-configuration in single-binary mode
+
+https://github.com/owncloud/ocis-konnectd/pull/55

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -113,10 +113,10 @@ func initKonnectInternalEnvVars() error {
 		"LDAP_BINDPW":              "konnectd",
 		"LDAP_BASEDN":              "ou=users,dc=example,dc=org",
 		"LDAP_SCOPE":               "sub",
-		"LDAP_LOGIN_ATTRIBUTE":     "uid",
+		"LDAP_LOGIN_ATTRIBUTE":     "cn",
 		"LDAP_EMAIL_ATTRIBUTE":     "mail",
-		"LDAP_NAME_ATTRIBUTE":      "cn",
-		"LDAP_UUID_ATTRIBUTE":      "customuid",
+		"LDAP_NAME_ATTRIBUTE":      "sn",
+		"LDAP_UUID_ATTRIBUTE":      "uid",
 		"LDAP_UUID_ATTRIBUTE_TYPE": "text",
 		"LDAP_FILTER":              "(objectClass=posixaccount)",
 	}


### PR DESCRIPTION
…figuration

- Konnectd uses no TLS as it is behind the proxy
- Glauth generates dev-certificates for ldap on startup if none are provided,
- Glauth can launch unencrypted (9125) and encrypted (9126) port in parallel

