### PR TITLE
add trailing slashes to phoenix redirect uris

### DIFF
--- a/assets/identifier-registration.yaml
+++ b/assets/identifier-registration.yaml
@@ -9,8 +9,8 @@ clients:
     trusted: yes
     redirect_uris:
       - http://localhost:9100/oidc-callback.html
-      - http://localhost:9100
-      - https://localhost:9200
+      - http://localhost:9100/
+      - https://localhost:9200/
       - https://localhost:9200/oidc-callback.html
     origins:
       - http://localhost:9100

--- a/changelog/unreleased/change_redirect_uri.md
+++ b/changelog/unreleased/change_redirect_uri.md
@@ -1,0 +1,5 @@
+Change: add a trailing slash to trusted redirect uris
+
+Phoenix changed the redirect uri to `<baseUrl>#/login` that means it will contain a trailing slash after the base url.
+
+https://github.com/owncloud/ocis-konnectd/issues/26


### PR DESCRIPTION
See https://github.com/owncloud/phoenix/pull/3291.
This change makes trailing slashes necessary.