### PR TITLE
add oidc-silent-redirect.html to allowed redirect uris

### DIFF
--- a/assets/identifier-registration.yaml
+++ b/assets/identifier-registration.yaml
@@ -8,13 +8,15 @@ clients:
     insecure: yes
     trusted: yes
     redirect_uris:
-      - http://localhost:9100/oidc-callback.html
-      - http://localhost:9100/
       - https://localhost:9200/
       - https://localhost:9200/oidc-callback.html
+      - https://localhost:9200/oidc-silent-redirect.html
+      - http://localhost:9100/
+      - http://localhost:9100/oidc-callback.html
+      - http://localhost:9100/oidc-silent-redirect.html
     origins:
-      - http://localhost:9100
       - https://localhost:9200
+      - http://localhost:9100
 
   - id: ocis-explorer.js
     name: OCIS Graph Explorer

--- a/changelog/unreleased/add-silent-redirect-url
+++ b/changelog/unreleased/add-silent-redirect-url
@@ -1,0 +1,6 @@
+Bugfix: add silent redirect url
+
+Adds the oidc-silent-redirect.html phoenix uses to silently refresh access tokens to the default identifier-registration.yml
+
+https://github.com/owncloud/ocis-konnectd/issues/69
+https://github.com/owncloud/ocis-konnectd/pull/70


### PR DESCRIPTION
first step for https://github.com/owncloud/ocis-konnectd/issues/69

fixes this error
```
https://localhost:9200/oidc-silent-redirect.html?error=access_denied&error_description=invalid redirect_uri: https://localhost:9200/oidc-silent-redirect.html&state=d35eaf93420e4fca97476b8321b793d8
```